### PR TITLE
Support DNSCrypt Relay stamps

### DIFF
--- a/dnsstamps/__init__.py
+++ b/dnsstamps/__init__.py
@@ -8,10 +8,12 @@ from .generator import create_dnscrypt
 from .generator import create_doh
 from .generator import create_dot
 from .generator import create_plain
+from .generator import create_dnscrypt_relay
 from .generator import prepare_dnscrypt
 from .generator import prepare_doh
 from .generator import prepare_dot
 from .generator import prepare_plain
+from .generator import prepare_dnscrypt_relay
 
 from .parser import parse
 

--- a/dnsstamps/formatter/formatter.py
+++ b/dnsstamps/formatter/formatter.py
@@ -61,6 +61,15 @@ def print_dot(parameter):
     print(build(parameter))
 
 
+def print_dnscrypt_relay(parameter):
+    print('DNSCrypt DNS Relay Stamp')
+    print('=============')
+    print('')
+    print('IP Address: %s' % parameter.address)
+    print('')
+    print(build(parameter))
+
+
 def format(parameter):
     if not isinstance(parameter, Parameter):
         raise ValueError('Invalid parameter type %s' % type(parameter))
@@ -73,3 +82,5 @@ def format(parameter):
         return print_doh(parameter)
     elif parameter.protocol == Protocol.DOT:
         return print_dot(parameter)
+    elif parameter.protocol == Protocol.DNSCRYPT_RELAY:
+        return print_dnscrypt_relay(parameter)

--- a/dnsstamps/generator/__init__.py
+++ b/dnsstamps/generator/__init__.py
@@ -3,7 +3,9 @@ from .generator import create_dnscrypt
 from .generator import create_doh
 from .generator import create_dot
 from .generator import create_plain
+from .generator import create_dnscrypt_relay
 from .generator import prepare_dnscrypt
 from .generator import prepare_doh
 from .generator import prepare_dot
 from .generator import prepare_plain
+from .generator import prepare_dnscrypt_relay

--- a/dnsstamps/generator/generator.py
+++ b/dnsstamps/generator/generator.py
@@ -111,6 +111,13 @@ def build_dot(parameter):
     )
 
 
+def build_dnscrypt_relay(parameter):
+    return create_stamp(
+        pack_protocol(parameter.protocol) +
+        pack_text(parameter.address)
+    )
+
+
 def build(parameter):
     if not isinstance(parameter, Parameter):
         raise ValueError('Invalid parameter type %s' % type(parameter))
@@ -123,6 +130,8 @@ def build(parameter):
         return build_doh(parameter)
     elif parameter.protocol == Protocol.DOT:
         return build_dot(parameter)
+    elif parameter.protocol == Protocol.DNSCRYPT_RELAY:
+        return build_dnscrypt_relay(parameter)
 
 
 def prepare_plain(address, options=None):
@@ -196,6 +205,13 @@ def prepare_dot(address, hashes, hostname, options=None, bootstrap_ips=None):
     return parameter
 
 
+def prepare_dnscrypt_relay(address):
+    parameter = Parameter()
+    parameter.protocol = Protocol.DNSCRYPT_RELAY
+    parameter.address = address
+    return parameter
+
+
 def create_plain(address, options=None):
     return build(prepare_plain(address, options))
 
@@ -210,3 +226,7 @@ def create_doh(address, hashes, hostname, path, options=None, bootstrap_ips=None
 
 def create_dot(address, hashes, hostname, options=None, bootstrap_ips=None):
     return build(prepare_dot(address, hashes, hostname, options, bootstrap_ips))
+
+
+def create_dnscrypt_relay(address):
+    return build(prepare_dnscrypt_relay(address))

--- a/dnsstamps/parser/parser.py
+++ b/dnsstamps/parser/parser.py
@@ -145,6 +145,10 @@ def parse_dot(state, parameter):
     parameter.bootstrap_ips = consume_text_array(state)
 
 
+def parse_dnscrypt_relay(state, parameter):
+    parameter.address = consume_text(state)
+
+
 def parse(stamp):
     parameter = Parameter()
 
@@ -159,5 +163,7 @@ def parse(stamp):
         parse_doh(state, parameter)
     elif parameter.protocol == Protocol.DOT:
         parse_dot(state, parameter)
+    elif parameter.protocol == Protocol.DNSCRYPT_RELAY:
+        parse_dnscrypt_relay(state, parameter)
 
     return parameter

--- a/dnsstamps/protocol.py
+++ b/dnsstamps/protocol.py
@@ -6,3 +6,4 @@ class Protocol(Enum):
     DNSCRYPT = 1
     DOH = 2
     DOT = 3
+    DNSCRYPT_RELAY = 4

--- a/dnsstamps/protocol.py
+++ b/dnsstamps/protocol.py
@@ -6,4 +6,4 @@ class Protocol(Enum):
     DNSCRYPT = 1
     DOH = 2
     DOT = 3
-    DNSCRYPT_RELAY = 4
+    DNSCRYPT_RELAY = 129

--- a/test/formatter/test_formatter.py
+++ b/test/formatter/test_formatter.py
@@ -39,3 +39,8 @@ class TestPrinter(unittest.TestCase):
         hostname = "doh.example.com"
         parameter = dnsstamps.prepare_dot(address, hashes, hostname)
         dnsstamps.format(parameter)
+
+    def test_format_dnscrypt_relay_stamp(self):
+        address = "[fe80::6d6d:f72c:3ad:60b8]"
+        parameter = dnsstamps.prepare_dnscrypt_relay(address)
+        dnsstamps.format(parameter)

--- a/test/formatter/test_formatter.py
+++ b/test/formatter/test_formatter.py
@@ -41,6 +41,6 @@ class TestPrinter(unittest.TestCase):
         dnsstamps.format(parameter)
 
     def test_format_dnscrypt_relay_stamp(self):
-        address = "[fe80::6d6d:f72c:3ad:60b8]"
+        address = "[fe80::6d6d:f72c:3ad:60b8]:433"
         parameter = dnsstamps.prepare_dnscrypt_relay(address)
         dnsstamps.format(parameter)

--- a/test/generator/test_generator.py
+++ b/test/generator/test_generator.py
@@ -171,8 +171,8 @@ class TestGenerator(unittest.TestCase):
             "Invalid stamp")
 
     def test_generate_dnscrypt_relay_stamp(self):
-        address = "127.0.0.1:53"
+        address = "127.0.0.1:443"
         self.assertEqual(
-            "sdns://BAwxMjcuMC4wLjE6NTM",
+            "sdns://gQ0xMjcuMC4wLjE6NDQz",
             dnsstamps.create_dnscrypt_relay(address),
             "Invalid stamp")

--- a/test/generator/test_generator.py
+++ b/test/generator/test_generator.py
@@ -169,3 +169,10 @@ class TestGenerator(unittest.TestCase):
             "sdns://AwUAAAAAAAAAAAAPZG90LmV4YW1wbGUuY29t",
             dnsstamps.create_dot(address, hashes, hostname, options),
             "Invalid stamp")
+
+    def test_generate_dnscrypt_relay_stamp(self):
+        address = "127.0.0.1:53"
+        self.assertEqual(
+            "sdns://BAwxMjcuMC4wLjE6NTM",
+            dnsstamps.create_dnscrypt_relay(address),
+            "Invalid stamp")

--- a/test/parser/test_parser.py
+++ b/test/parser/test_parser.py
@@ -183,7 +183,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual([], parameter.bootstrap_ips, "Invalid bootstrap_ips")
 
     def test_parse_dnscrypt_relay_stamp(self):
-        parameter = dnsstamps.parse("sdns://BAwxMjcuMC4wLjE6NTM")
+        parameter = dnsstamps.parse("sdns://gQ0xMjcuMC4wLjE6NDQz")
 
         self.assertEqual(Protocol.DNSCRYPT_RELAY, parameter.protocol, "Invalid protocol")
-        self.assertEqual("127.0.0.1:53", parameter.address, "Invalid address")
+        self.assertEqual("127.0.0.1:443", parameter.address, "Invalid address")

--- a/test/parser/test_parser.py
+++ b/test/parser/test_parser.py
@@ -181,3 +181,9 @@ class TestParser(unittest.TestCase):
         self.assertEqual([], parameter.hashes, "Invalid hashes")
         self.assertEqual("dot.example.com", parameter.hostname, "Invalid hostname")
         self.assertEqual([], parameter.bootstrap_ips, "Invalid bootstrap_ips")
+
+    def test_parse_dnscrypt_relay_stamp(self):
+        parameter = dnsstamps.parse("sdns://BAwxMjcuMC4wLjE6NTM")
+
+        self.assertEqual(Protocol.DNSCRYPT_RELAY, parameter.protocol, "Invalid protocol")
+        self.assertEqual("127.0.0.1:53", parameter.address, "Invalid address")


### PR DESCRIPTION
Hi Christian,

I added support for DNSCrypt relay stamps as mentioned in the [specification](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/stamps#anonymized-dnscrypt-relay-stamps). This PR should all required code for the parser, generator, formatter and some simple test cases. Let me know what you think.

tunefish