### PR TITLE
In pack_text, encode the length after utf-8 encoding

### DIFF
--- a/dnsstamps/generator/generator.py
+++ b/dnsstamps/generator/generator.py
@@ -33,11 +33,12 @@ def pack_text_array(array):
 
 
 def pack_text(text, set_high_bit=False):
-    length = len(text)
+    encoded = text.encode('utf-8')
+    length = len(encoded)
     if set_high_bit:
         length |= (1 << 7)
 
-    return struct.pack("<B", length) + text.encode('utf-8')
+    return struct.pack("<B", length) + encoded
 
 
 def pack_raw_array(array):


### PR DESCRIPTION
The length is the number of bytes, not the number of characters, so it should be computed after utf-8 encoding.